### PR TITLE
Working if then else

### DIFF
--- a/src/main/java/compiler/frontend/IRBuilder.java
+++ b/src/main/java/compiler/frontend/IRBuilder.java
@@ -149,6 +149,7 @@ public class IRBuilder extends SimpleCBaseVisitor<BuilderResult> {
 	@Override
 	public BuilderResult visitReturnExpr(ReturnExprContext ctx) {
 		BuilderResult res = this.visit(ctx.body);
+
 		IRReturn newInstr = new IRReturn(res.value);
 		currentBlock.addOperation(newInstr);
 
@@ -218,10 +219,9 @@ public class IRBuilder extends SimpleCBaseVisitor<BuilderResult> {
 			return new BuilderResult(true, begin, end, new IRValue(IRType.VOID, null));
 		}
 
-		// IRBlock entry_else_block = currentFunction.addBlock();
-		// currentBlock = entry_else_block;
+		IRBlock entry_else_block = currentFunction.addBlock();
+		currentBlock = entry_else_block;
 		BuilderResult else_block = this.visit(ctx.elseBody);
-		// else_block.entry = entry_else_block;
 
 		if (else_block.entry == null) {
 			throw new RuntimeException("Else block is not empty but the entry block is null");
@@ -238,7 +238,6 @@ public class IRBuilder extends SimpleCBaseVisitor<BuilderResult> {
 
 		// Link if to the End block
 		if_block.exit.addTerminator(gotoEnd);
-
 
 		// Link else to the End block
 		else_block.exit.addTerminator(gotoEnd);


### PR DESCRIPTION
- we add a empty block but it's working (when if {} else if {} else {}) for simple if {} else {} it works also but no empty block
- problem with the fact that now things that ahs type VOID return an IRValue VOID without defining the variable of type VOID. TODO fix in translation unit ( if it is of type void just "return;")